### PR TITLE
chore(pages): remove Pages Functions (delete functions/api)

### DIFF
--- a/functions/api/calc.ts
+++ b/functions/api/calc.ts
@@ -1,3 +1,0 @@
-export default async (c) => {
-  return c.json({ message: 'Calc API working!' });
-}


### PR DESCRIPTION
حذف مجلد functions/api لإيقاف Pages Functions.

إجبار Pages على استخدام dist/_worker.js فقط.

تمهيدًا للنشر السلس على Pages.